### PR TITLE
Bump gcp-storage-emulator and drop setuptools pin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,6 @@
 coverage[toml]==7.15.2
 flake8==7.3.0
-gcp-storage-emulator==2024.8.3
+gcp-storage-emulator==2026.7.18
 moto[s3]==5.2.2
 mypy==2.3.0
 pylint==4.0.6
-# setuptools>=82 removed pkg_resources; fs (via gcp-storage-emulator) still needs it
-setuptools>=70,<82


### PR DESCRIPTION
The 2026.7.18 emulator no longer depends on pyfilesystem2, so pkg_resources / setuptools<82 is not required for tests.