### PR TITLE
Fix total selling prices to match sum of detail rows

### DIFF
--- a/ibkr_report/report.py
+++ b/ibkr_report/report.py
@@ -111,7 +111,6 @@ class Report:
             == DataDiscriminator.TRADE
         ):
             self._trade = Trade(items, self.options, self.rates)
-            self.prices += self._trade.total_selling_price
         if (
             items[self.options.fields[Field.DATA_DISCRIMINATOR]]
             == DataDiscriminator.CLOSED_LOT
@@ -119,6 +118,8 @@ class Report:
             if not self._trade:
                 raise ValueError("Tried to close a lot without trades.")
             details = self._trade.details_from_closed_lot(items)
+            # Sum detail prices so the total matches the result table (#1458).
+            self.prices += details.price
             if details.realized > 0:
                 self.gains += details.realized
             else:

--- a/ibkr_report/trade.py
+++ b/ibkr_report/trade.py
@@ -27,7 +27,6 @@ class Trade:
 
     fee: Decimal = Decimal(0)
     closed_quantity: Decimal = Decimal(0)
-    total_selling_price: Decimal = Decimal(0)
     data: RowData
     options: ReportOptions
     rates: ExchangeRates
@@ -35,18 +34,13 @@ class Trade:
     def __init__(
         self, items: Tuple[str, ...], options: ReportOptions, rates: ExchangeRates
     ) -> None:
-        """Initializes the Trade and calculates the total selling price from it."""
+        """Initializes the Trade from a CSV Trade row."""
         self.options = options
         self.rates = rates
         self.data = self._row_data(items)
 
         fee = decimal_cleanup(items[self.options.fields[Field.COMMISSION_AND_FEES]])
         self.fee = fee / self.data.rate
-
-        # Sold stocks have a negative value in the "Quantity" column
-        if self.data.quantity < Decimal(0):
-            proceeds = decimal_cleanup(items[self.options.fields[Field.PROCEEDS]])
-            self.total_selling_price = proceeds / self.data.rate
         log.debug(
             'Trade: "%s" "%s" %.2f',
             self.data.date_str,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -66,6 +66,45 @@ class ReportTest(unittest.TestCase):
         self.assertEqual(report.details[0].buy_date, "2022-11-23")
         self.assertEqual(report.details[0].sell_date, "2022-11-24")
 
+    def test_prices_match_sum_of_detail_selling_prices(self):
+        """Total selling prices must equal the sum of detail row prices.
+
+        Previously totals used Trade Proceeds while details used ClosedLot-based
+        prices, which diverged for shorts/options (issue #1458).
+        """
+        fixtures = (
+            "tests/test-data/data_single_account.csv",
+            "tests/test-data/data_multi_account.csv",
+            "tests/test-data/data_shorting_stocks.csv",
+            "tests/test-data/data_numbers_within_quotes.csv",
+            "tests/test-data/data_warrants.csv",
+            "tests/test-data/data_deemed_acquisition_cost.csv",
+            "tests/test-data/data_single_account_2022.csv",
+        )
+        for path in fixtures:
+            with self.subTest(path=path):
+                Cache.clear()
+                report = Report(use_deemed_acquisition_cost=False)
+                with open(path, "rb") as file:
+                    report.add_trades(file)
+                detail_sum = sum((d.price for d in report.details), Decimal(0))
+                self.assertEqual(report.prices, detail_sum, path)
+
+    def test_sell_without_closed_lot_does_not_count_prices(self):
+        """A Trade sell/short with no ClosedLot must not inflate totals."""
+        csv_data = (
+            b"Trades,Header,DataDiscriminator,Asset Category,Currency,Symbol,"
+            b"Date/Time,Quantity,T. Price,Proceeds,Comm/Fee\n"
+            b'Trades,Data,Trade,Stocks,EUR,ABC,"2020-06-15, 10:00:00",'
+            b"-100,10,1000,-1\n"
+        )
+        report = Report(use_deemed_acquisition_cost=False)
+        report.add_trades(csv_data.splitlines())
+        self.assertEqual(report.prices, Decimal(0))
+        self.assertEqual(report.details, [])
+        self.assertEqual(report.gains, Decimal(0))
+        self.assertEqual(report.losses, Decimal(0))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -59,7 +59,7 @@ class SmokeTests(unittest.TestCase):
         response = self.app.post("/result?json", data=data)
         self.assertEqual(response.status_code, 200)
         data_json = json.loads(response.data)
-        self.assertEqual(data_json["prices"], 6873.02)
+        self.assertEqual(data_json["prices"], 6870.76)
         self.assertEqual(data_json["gains"], 1064.02)
         self.assertEqual(data_json["losses"], 445.98)
 
@@ -73,7 +73,7 @@ class SmokeTests(unittest.TestCase):
         response = self.app.post("/result?json", data=data)
         self.assertEqual(response.status_code, 200)
         data_json = json.loads(response.data)
-        self.assertEqual(data_json["prices"], 6034.30)
+        self.assertEqual(data_json["prices"], 6033.44)
         self.assertEqual(data_json["gains"], 2644.18)
         self.assertEqual(data_json["losses"], 0.00)
 
@@ -82,7 +82,8 @@ class SmokeTests(unittest.TestCase):
         response = self.app.post("/result?json", data=data)
         self.assertEqual(response.status_code, 200)
         data_json = json.loads(response.data)
-        self.assertEqual(data_json["prices"], 6034.30)
+        # Open short without ClosedLot: no disposal row, so no selling price.
+        self.assertEqual(data_json["prices"], 0.0)
         self.assertEqual(data_json["gains"], 0.00)
         self.assertEqual(data_json["losses"], 0.00)
 


### PR DESCRIPTION
Fixes #1458

Accumulate selling price from each ClosedLot detail instead of Trade Proceeds, so the reported total matches the result table. Remove unused Trade.total_selling_price. Open sells/shorts without ClosedLots no longer inflate the total.