### PR TITLE
Speed up ARM Docker CI with native runners and prod-only builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,13 +71,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build
@@ -88,18 +81,41 @@ jobs:
           platforms: ${{ matrix.arch }}
           push: false
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          # Stable local tag for smoke tests (metadata tags are PR/ref-specific).
+          tags: ${{ env.REPO_NAME }}:ci
           cache-from: type=gha,scope=docker-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
       - name: Docker container up
-        run: docker run -d --rm -p 8080:8080 --name ${{ env.REPO_NAME }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          docker run -d --rm -p 8080:8080 --name "${{ env.REPO_NAME }}" "${{ env.REPO_NAME }}:ci"
+          docker ps -a --filter "name=${{ env.REPO_NAME }}"
       - name: Check the container reachability
-        run: curl -s --retry 10 --retry-connrefused --retry-delay 1 http://localhost:8080/
+        run: |
+          set -e
+          for i in $(seq 1 30); do
+            if ! docker ps --filter "name=${{ env.REPO_NAME }}" --filter "status=running" --format '{{.Names}}' | grep -q .; then
+              echo "Container is not running (attempt ${i})"
+              docker ps -a --filter "name=${{ env.REPO_NAME }}" || true
+              docker logs "${{ env.REPO_NAME }}" || true
+              exit 1
+            fi
+            if curl -sf --max-time 2 "http://127.0.0.1:8080/" >/dev/null; then
+              echo "Service is up"
+              curl -sS "http://127.0.0.1:8080/" | head -c 200
+              echo
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Timed out waiting for service"
+          docker logs "${{ env.REPO_NAME }}" || true
+          exit 1
       - name: Check Docker logs
-        run: docker logs ${{ env.REPO_NAME }}
+        if: always()
+        run: docker logs "${{ env.REPO_NAME }}" || true
       - name: Docker container down
-        run: docker stop ${{ env.REPO_NAME }}
+        if: always()
+        run: docker stop "${{ env.REPO_NAME }}" || true
 
   publish:
     if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,10 +60,15 @@ jobs:
           flags: unittests
 
   docker:
-    runs-on: ubuntu-24.04
+    # Native runners: arm64 is built on ARM hardware (no QEMU).
     strategy:
       matrix:
-        arch: ['linux/amd64', 'linux/arm64']
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-24.04
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - name: Docker meta
@@ -73,43 +78,24 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Cache Docker layers
-        uses: actions/cache@v6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-build-x-${{ matrix.arch }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-build-x-${{ matrix.arch }}-
       - name: Build
         uses: docker/build-push-action@v7.3.0
         with:
+          context: .
+          target: prod
           platforms: ${{ matrix.arch }}
           push: false
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
       - name: Docker container up
         run: docker run -d --rm -p 8080:8080 --name ${{ env.REPO_NAME }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Wait 10 seconds
-        run: sleep 10
-      - name: Check running containers
-        run: docker ps -a
       - name: Check the container reachability
-        run: curl -s --retry 10 --retry-connrefused http://localhost:8080/
+        run: curl -s --retry 10 --retry-connrefused --retry-delay 1 http://localhost:8080/
       - name: Check Docker logs
         run: docker logs ${{ env.REPO_NAME }}
       - name: Docker container down
@@ -128,38 +114,28 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=true
+      # Multi-arch push still cross-builds arm64 here; prod-only + GHA cache keeps it short.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Cache Docker layers
-        uses: actions/cache@v6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-build-x-multi-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-build-x-multi-
       - name: Login to Container Registry
         uses: docker/login-action@v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build
+      - name: Build and push
         uses: docker/build-push-action@v7.3.0
         with:
+          context: .
+          target: prod
           platforms: linux/amd64,linux/arm64
           push: true
-          load: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: |
+            type=gha,scope=docker-linux/amd64
+            type=gha,scope=docker-linux/arm64
+            type=gha,scope=docker-publish
+          cache-to: type=gha,mode=max,scope=docker-publish

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,13 +67,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: Set REPO_NAME
         run: echo "REPO_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build
@@ -84,15 +77,37 @@ jobs:
           platforms: ${{ matrix.arch }}
           push: false
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REPO_NAME }}:ci
           cache-from: type=gha,scope=docker-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
       - name: Docker container up
-        run: docker run -d --rm -p 8080:8080 --name ${{ env.REPO_NAME }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          docker run -d --rm -p 8080:8080 --name "${{ env.REPO_NAME }}" "${{ env.REPO_NAME }}:ci"
+          docker ps -a --filter "name=${{ env.REPO_NAME }}"
       - name: Check the container reachability
-        run: curl -s --retry 10 --retry-connrefused --retry-delay 1 http://localhost:8080/
+        run: |
+          set -e
+          for i in $(seq 1 30); do
+            if ! docker ps --filter "name=${{ env.REPO_NAME }}" --filter "status=running" --format '{{.Names}}' | grep -q .; then
+              echo "Container is not running (attempt ${i})"
+              docker ps -a --filter "name=${{ env.REPO_NAME }}" || true
+              docker logs "${{ env.REPO_NAME }}" || true
+              exit 1
+            fi
+            if curl -sf --max-time 2 "http://127.0.0.1:8080/" >/dev/null; then
+              echo "Service is up"
+              curl -sS "http://127.0.0.1:8080/" | head -c 200
+              echo
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Timed out waiting for service"
+          docker logs "${{ env.REPO_NAME }}" || true
+          exit 1
       - name: Check Docker logs
-        run: docker logs ${{ env.REPO_NAME }}
+        if: always()
+        run: docker logs "${{ env.REPO_NAME }}" || true
       - name: Docker container down
-        run: docker stop ${{ env.REPO_NAME }}
+        if: always()
+        run: docker stop "${{ env.REPO_NAME }}" || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,10 +55,14 @@ jobs:
           coverage xml
 
   docker:
-    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        arch: ['linux/amd64', 'linux/arm64']
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-24.04
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
       - name: Set REPO_NAME
@@ -70,43 +74,24 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Cache Docker layers
-        uses: actions/cache@v6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-build-x-${{ matrix.arch }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-build-x-${{ matrix.arch }}-
       - name: Build
         uses: docker/build-push-action@v7.3.0
         with:
+          context: .
+          target: prod
           platforms: ${{ matrix.arch }}
           push: false
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
       - name: Docker container up
         run: docker run -d --rm -p 8080:8080 --name ${{ env.REPO_NAME }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Wait 10 seconds
-        run: sleep 10
-      - name: Check running containers
-        run: docker ps -a
       - name: Check the container reachability
-        run: curl -s --retry 10 --retry-connrefused http://localhost:8080/
+        run: curl -s --retry 10 --retry-connrefused --retry-delay 1 http://localhost:8080/
       - name: Check Docker logs
         run: docker logs ${{ env.REPO_NAME }}
       - name: Docker container down

--- a/.github/workflows/publish-to-ghcr.yml
+++ b/.github/workflows/publish-to-ghcr.yml
@@ -22,13 +22,6 @@ jobs:
       uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
-    - name: Cache Docker layers
-      uses: actions/cache@v6
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-build-x-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-build-x-
     - name: Login to Container Registry
       uses: docker/login-action@v4.4.0
       with:
@@ -39,11 +32,13 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v7.3.0
       with:
+        context: .
+        target: prod
         platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+        cache-from: type=gha,scope=docker-publish
+        cache-to: type=gha,mode=max,scope=docker-publish
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,15 @@ COPY main.py pyproject.toml setup.py MANIFEST.in README.md LICENSE ./
 COPY ibkr_report/ ./ibkr_report/
 RUN pip3 install --no-cache-dir -e .[aws,docker,gcp]
 
+# Optional local/debug stage: docker build --target test
 FROM base AS test
 COPY tests/ ./tests/
 COPY requirements-dev.txt ./
 RUN pip3 install --no-cache-dir -r requirements-dev.txt && \
     coverage run -m unittest discover && \
-    coverage report -m && \
-    coverage xml
+    coverage report -m
 
+# Default production image (CI smoke + GHCR). Unit tests run on GitHub Actions runners.
 FROM base AS prod
-COPY --from=test ${APP_HOME}/coverage.xml .
 ENTRYPOINT []
 CMD ["sh", "-c", "gunicorn --bind :$PORT --workers $GUNICORN_WORKERS --threads $GUNICORN_THREADS --timeout 0 main:app"]


### PR DESCRIPTION
Stop running unit tests and installing requirements-dev inside the image (tests already run on the Python matrix). Build the prod target on native amd64/arm64 runners with GHA Buildx cache, and drop the fixed sleep in favor of curl retries. Publish jobs use the same prod target and cache scopes so multi-arch pushes avoid redundant work.